### PR TITLE
Failsafe when adding lab_users when no labs available

### DIFF
--- a/app/controllers/lab_users_controller.rb
+++ b/app/controllers/lab_users_controller.rb
@@ -194,12 +194,16 @@ class LabUsersController < ApplicationController
       @lab=Lab.first
       redirect_to(add_users_path) if params[:id]!=nil
     end
-    session[:lab_id]=@lab.id # remember for next time
-    #users already in the particular lab
-    @users_in=[]
-    @lab.lab_users.each do |u|
-      @users_in<<u.user
-    end
+    begin
+      session[:lab_id]=@lab.id # remember for next time
+      #users already in the particular lab
+      @users_in=[]
+      @lab.lab_users.each do |u|
+        @users_in<<u.user
+      end
+    rescue StandardError
+      redirect_to users_path, notice: "No labs are added to I-Tee, therefore this action is not available."
+    end 
   end
   
   def import


### PR DESCRIPTION
Throws an error message instead of generic "something went wrong" page in case someone tries to add new user to lab, when no labs are added to system yet.